### PR TITLE
Fixed a parsing error in COMM, PIC and USLT frames

### DIFF
--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -269,8 +269,7 @@ macro_rules! decode_part {
 
             let start = $i;
             $i += $len;
-
-            try!(String::from_utf8($bytes[start..$i].to_vec()))
+            try!(::util::string_from_latin1(&$bytes[start..$i]))
         }
     };
     ($bytes:ident, $params:ident, $i:ident, latin1($terminated:expr)) => {


### PR DESCRIPTION
The ID3v2 spec does not mention any text encoding when describing the language bytes of the COMM/USLT frames or the format bytes of the 2.2 PIC frame.

I think this portion of the 2.4 spec indicates that ISO-8859-1 is the correct encoding to assume here:

> If nothing else is said, strings, including numeric strings and URLs  [URL], are represented as ISO-8859-1 [ISO-8859-1] characters in the range $20 - $FF.

Similarly, in the 2.2 spec, justifying the change for the PIC frame:

> If nothing else is said a string is represented as ISO-8859-1 [ISO-8859-1] characters in the range $20 - $FF.