### PR TITLE
Be more lenient in accepting picture types

### DIFF
--- a/src/frame/content.rs
+++ b/src/frame/content.rs
@@ -196,6 +196,36 @@ pub enum PictureType {
     Illustration,
     BandLogo,
     PublisherLogo,
+    Undefined(u8),
+}
+
+impl From<PictureType> for u8{
+    fn from(pt: PictureType) -> Self {
+        match pt {
+            PictureType::Other => 0,
+            PictureType::Icon => 1,
+            PictureType::OtherIcon => 2,
+            PictureType::CoverFront => 3,
+            PictureType::CoverBack => 4,
+            PictureType::Leaflet => 5,
+            PictureType::Media => 6,
+            PictureType::LeadArtist => 7,
+            PictureType::Artist => 8,
+            PictureType::Conductor => 9,
+            PictureType::Band => 10,
+            PictureType::Composer => 11,
+            PictureType::Lyricist => 12,
+            PictureType::RecordingLocation => 13,
+            PictureType::DuringRecording => 14,
+            PictureType::DuringPerformance => 15,
+            PictureType::ScreenCapture => 16,
+            PictureType::BrightFish => 17,
+            PictureType::Illustration => 18,
+            PictureType::BandLogo => 19,
+            PictureType::PublisherLogo => 20,
+            PictureType::Undefined(b) => b,
+        }
+    }
 }
 
 /// A structure representing an ID3 picture frame's contents.

--- a/src/stream/frame/content.rs
+++ b/src/stream/frame/content.rs
@@ -189,7 +189,7 @@ fn picture_to_bytes_v3(request: EncoderRequest) -> Vec<u8> {
         encoding(request.encoding),
         bytes(content.mime_type.as_bytes()),
         byte(0),
-        byte(content.picture_type),
+        byte(u8::from(content.picture_type)),
         string(content.description),
         delim(0),
         bytes(content.data)
@@ -206,7 +206,7 @@ fn picture_to_bytes_v2(request: EncoderRequest) -> crate::Result<Vec<u8>> {
     Ok(encode!(
         encoding(request.encoding),
         bytes(format.as_bytes()),
-        byte(picture.picture_type),
+        byte(u8::from(picture.picture_type)),
         string(picture.description),
         delim(0),
         bytes(picture.data)
@@ -362,7 +362,7 @@ macro_rules! decode_part {
             18 => PictureType::Illustration,
             19 => PictureType::BandLogo,
             20 => PictureType::PublisherLogo,
-            _ => return Err(Error::new(ErrorKind::Parsing, "invalid picture type")),
+            b  => PictureType::Undefined(b),
         };
         (ty, &$bytes[1..])
     }};
@@ -535,7 +535,7 @@ mod tests {
                     let mut data = Vec::new();
                     data.push(*encoding as u8);
                     data.extend(format.bytes());
-                    data.push(picture_type as u8);
+                    data.push(picture_type.into());
                     data.extend(bytes_for_encoding(description, *encoding).into_iter());
                     data.extend(delim_for_encoding(*encoding).into_iter());
                     data.extend(picture_data.iter().cloned());
@@ -584,7 +584,7 @@ mod tests {
                     data.push(*encoding as u8);
                     data.extend(mime_type.bytes());
                     data.push(0x0);
-                    data.push(picture_type as u8);
+                    data.push(picture_type.into());
                     data.extend(bytes_for_encoding(description, *encoding).into_iter());
                     data.extend(delim_for_encoding(*encoding).into_iter());
                     data.extend(picture_data.iter().cloned());


### PR DESCRIPTION
I just encountered a case in my collection where the mp3 file couldn't be parsed because of a "invalid picture type". 
I don't know which program set this wrong type (it was 0xFF) but I didn't notice it before because all other programs (eg. VLC, MP3Tag, mpd, the android music player) could handle the file and its picture just fine.

So I thought that this lenient handling of `PictureType` could be appropriate here, too.
For this, I introduced the `Undefined(u8)` variant and removed the thrown parsing error.

This has the benefit that a slightly mismatched file can at least be used for the other tags.

This is a breaking change for all dependent crates which read the PictureType while trying to match all types, but as far as I can find, no one uses this. (at least in crates on crates.io and the public github projects)
